### PR TITLE
Add sub title topbar to be guid

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
     defaultConfig {
         applicationId 'org.rfcx.incidents'
         manifestPlaceholders = [auth0Domain: "@string/auth0_domain", auth0Scheme: "@string/auth0_scheme"]
-        versionCode 59
-        versionName '1.1.4'
+        versionCode 60
+        versionName '1.1.5'
         minSdkVersion 21
         targetSdkVersion 33
         multiDexEnabled true

--- a/app/src/main/java/org/rfcx/incidents/view/guardian/GuardianDeploymentActivity.kt
+++ b/app/src/main/java/org/rfcx/incidents/view/guardian/GuardianDeploymentActivity.kt
@@ -147,6 +147,12 @@ class GuardianDeploymentActivity : AppCompatActivity(), GuardianDeploymentEventL
         }
     }
 
+    override fun setToolbarSubTitle(subTitle: String) {
+        supportActionBar?.apply {
+            this.subtitle = subTitle
+        }
+    }
+
     override fun isAbleToDeploy(): Boolean {
         if (!passedScreen.contains(GuardianScreen.REGISTER)) return false
         if (!passedScreen.contains(GuardianScreen.NETWORK_TEST)) return false

--- a/app/src/main/java/org/rfcx/incidents/view/guardian/GuardianDeploymentEventListener.kt
+++ b/app/src/main/java/org/rfcx/incidents/view/guardian/GuardianDeploymentEventListener.kt
@@ -15,6 +15,7 @@ interface GuardianDeploymentEventListener {
     fun showThreeDots()
     fun hideThreeDots()
     fun setToolbarTitle(title: String)
+    fun setToolbarSubTitle(subTitle: String)
 
     fun isAbleToDeploy(): Boolean
     fun changeScreen(screen: GuardianScreen)

--- a/app/src/main/java/org/rfcx/incidents/view/guardian/checklist/GuardianCheckListFragment.kt
+++ b/app/src/main/java/org/rfcx/incidents/view/guardian/checklist/GuardianCheckListFragment.kt
@@ -59,6 +59,7 @@ class GuardianCheckListFragment : Fragment(), (Int, String) -> Unit {
         lifecycleScope.launchWhenStarted {
             launch { collectCheckListItem() }
             launch { collectRegistration() }
+            launch { collectGuardianId() }
         }
     }
 
@@ -76,6 +77,16 @@ class GuardianCheckListFragment : Fragment(), (Int, String) -> Unit {
                 if (it) {
                     mainEvent?.setPassedScreen(GuardianScreen.REGISTER)
                     viewModel.getAllCheckList(mainEvent?.getPassedScreen())
+                }
+            }
+        }
+    }
+
+    private fun collectGuardianId() {
+        lifecycleScope.launch {
+            viewModel.guardianIdState.collectLatest {
+                if (it.isNotEmpty()) {
+                    mainEvent?.setToolbarSubTitle(it)
                 }
             }
         }

--- a/app/src/main/java/org/rfcx/incidents/view/guardian/checklist/GuardianCheckListViewModel.kt
+++ b/app/src/main/java/org/rfcx/incidents/view/guardian/checklist/GuardianCheckListViewModel.kt
@@ -41,6 +41,9 @@ class GuardianCheckListViewModel(
     private val _registrationState: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val registrationState = _registrationState.asStateFlow()
 
+    private val _guardianIdState: MutableStateFlow<String> = MutableStateFlow("")
+    val guardianIdState = _guardianIdState.asStateFlow()
+
     private var guid = ""
     private var token = ""
     private var guardianVital = ""
@@ -56,6 +59,7 @@ class GuardianCheckListViewModel(
             getAdminMessageUseCase.launch().combine(getGuardianMessageUseCase.launch()) { admin, guardian ->
                 guardian?.getGuid()?.let {
                     guid = it
+                    _guardianIdState.tryEmit(it)
                 }
                 guardian?.getGuardianToken()?.let {
                     token = it


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #387 
- [x] Version bumped

_(use na when Release notes, etc do not need to be updated)_

## 📝 Summary

- Add guid under section title in guardian deployment
![Screenshot 2566-10-17 at 19 02 30](https://github.com/rfcx/guardian-app-android/assets/44440424/529f9745-4986-453a-a4f1-9b1d1a3712d9)
![Screenshot 2566-10-17 at 19 02 39](https://github.com/rfcx/guardian-app-android/assets/44440424/c7a0e7e9-f8f0-499e-91c9-44c253deeed1)
![Screenshot 2566-10-17 at 19 02 47](https://github.com/rfcx/guardian-app-android/assets/44440424/cac5c0d9-7ec1-4f8b-b997-ab1ca2de0c2e)
