### PR TITLE
feat(analytics): replace Firebase Analytics with self-hosted PostHog

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,9 @@ android {
         targetSdk 34
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // Self-hosted PostHog (track.rfcx.org, RFCx project). Public client token.
+        buildConfigField 'String', 'POSTHOG_API_KEY', '"phc_zQeWTDJUoE3tXnEcNZPMpC5DL353MDturnpsdtaQEQpe"'
+        buildConfigField 'String', 'POSTHOG_HOST', '"https://track.rfcx.org"'
     }
     buildTypes {
         debug {
@@ -111,7 +114,10 @@ dependencies {
 
     // Add the Firebase Crashlytics SDK.
     implementation 'com.google.firebase:firebase-crashlytics:18.3.5'
-    implementation 'com.google.firebase:firebase-analytics:21.2.0'
+    // firebase-analytics removed 2026-07-15 — product analytics is self-hosted
+    // PostHog now (below); Crashlytics/Config/Messaging/Firestore/Storage stay.
+    // Self-hosted product analytics (track.rfcx.org). Replaces Firebase Analytics.
+    implementation 'com.posthog:posthog-android:3.+'
 
     /* stetho */
     implementation 'com.facebook.stetho:stetho:1.5.0'

--- a/app/src/main/java/org/rfcx/incidents/Application.kt
+++ b/app/src/main/java/org/rfcx/incidents/Application.kt
@@ -97,6 +97,9 @@ class Application : MultiDexApplication(), LifecycleObserver {
             captureScreenViews = false
             captureDeepLinks = false
             sessionReplay = false
+            // We don't use PostHog feature flags/surveys here — skip the preload
+            // network call (conservative). Event capture is unaffected.
+            preloadFeatureFlags = false
         }
         PostHogAndroid.setup(this, config)
     }

--- a/app/src/main/java/org/rfcx/incidents/Application.kt
+++ b/app/src/main/java/org/rfcx/incidents/Application.kt
@@ -12,6 +12,8 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.multidex.MultiDex
 import androidx.multidex.MultiDexApplication
 import com.facebook.stetho.Stetho
+import com.posthog.android.PostHogAndroid
+import com.posthog.android.PostHogAndroidConfig
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
@@ -41,6 +43,7 @@ class Application : MultiDexApplication(), LifecycleObserver {
 
         MultiDex.install(this)
 
+        setupPostHog()
         AppRealm.init(this)
         setupKoin()
         ResponseCleanupWorker.enqueuePeriodically()
@@ -80,6 +83,22 @@ class Application : MultiDexApplication(), LifecycleObserver {
             DataModule.remoteModule,
             DataModule.dataModule
         )
+    }
+
+    // Self-hosted PostHog product analytics (replaces Firebase Analytics).
+    // Conservative config, consistent with the other rfcx clients: no screen-view
+    // autocapture (screens are sent manually via Analytics.trackScreen), no deep
+    // link autocapture, no session replay. App lifecycle events are kept.
+    private fun setupPostHog() {
+        val config = PostHogAndroidConfig(
+            apiKey = BuildConfig.POSTHOG_API_KEY,
+            host = BuildConfig.POSTHOG_HOST
+        ).apply {
+            captureScreenViews = false
+            captureDeepLinks = false
+            sessionReplay = false
+        }
+        PostHogAndroid.setup(this, config)
     }
 
     private fun setupKoin() {

--- a/app/src/main/java/org/rfcx/incidents/util/Analytics.kt
+++ b/app/src/main/java/org/rfcx/incidents/util/Analytics.kt
@@ -1,9 +1,15 @@
 package org.rfcx.incidents.util
 
-import android.app.Activity
 import android.content.Context
 import android.os.Bundle
-import com.google.firebase.analytics.FirebaseAnalytics
+import com.posthog.PostHog
+
+// Product analytics is self-hosted PostHog (track.rfcx.org) as of 2026-07-15,
+// replacing Firebase Analytics. Firebase Crashlytics/Config/Messaging/Firestore/
+// Storage stay. The public API of this class + every call site are unchanged;
+// only the two backing methods send to PostHog now. Firebase reserved event/param
+// names are preserved verbatim (login, item_name, ...) so the taxonomy is
+// byte-identical — only the destination changed.
 
 enum class Screen(val id: String) {
     LOGIN("Login"),
@@ -26,30 +32,52 @@ enum class Screen(val id: String) {
 }
 
 class Analytics(context: Context) {
-    private var firebaseAnalytics = FirebaseAnalytics.getInstance(context)
     private var context: Context? = context
+
+    // Firebase reserved event/param string values, preserved so the taxonomy is
+    // byte-identical after moving off Firebase Analytics.
+    private object FA {
+        const val EVENT_LOGIN = "login"
+        const val PARAM_METHOD = "method"
+        const val PARAM_ITEM_NAME = "item_name"
+        const val PARAM_ITEM_ID = "item_id"
+        const val PARAM_SOURCE = "source"
+        const val PARAM_VALUE = "value"
+    }
+
+    // Convert the existing Firebase Bundle params to the Map PostHog expects.
+    private fun Bundle.toMap(): Map<String, Any> {
+        val map = HashMap<String, Any>()
+        for (key in keySet()) {
+            @Suppress("DEPRECATION")
+            get(key)?.let { map[key] = it }
+        }
+        return map
+    }
 
     // region track screen
     fun trackScreen(screen: Screen) {
-        firebaseAnalytics.setCurrentScreen(context as Activity, screen.id, null)
+        // Manual screen capture (autocapture is off). PostHog's screen event.
+        PostHog.screen(screen.id)
     }
 
     // region track event
 
     private fun trackEvent(eventName: String, params: Bundle) {
-        firebaseAnalytics.setUserProperty("user_email", context?.getUserEmail())
-        firebaseAnalytics.logEvent(eventName, params)
+        // Identity = the signed-in user's email (matches the old user_email prop).
+        context?.getUserEmail()?.takeIf { it.isNotEmpty() }?.let { PostHog.identify(it) }
+        PostHog.capture(eventName, properties = params.toMap())
     }
 
     fun trackLoginEvent(method: String) {
         val bundle = Bundle()
-        bundle.putString(FirebaseAnalytics.Param.METHOD, method)
-        trackEvent(FirebaseAnalytics.Event.LOGIN, bundle)
+        bundle.putString(FA.PARAM_METHOD, method)
+        trackEvent(FA.EVENT_LOGIN, bundle)
     }
 
     fun trackEnterInviteCodeEvent(inviteCode: String) {
         val bundle = Bundle()
-        bundle.putString(FirebaseAnalytics.Param.ITEM_NAME, inviteCode)
+        bundle.putString(FA.PARAM_ITEM_NAME, inviteCode)
         trackEvent("enter_invite_code", bundle)
     }
 
@@ -85,42 +113,42 @@ class Analytics(context: Context) {
 
     fun trackSatelliteCount(count: Int) {
         val bundle = Bundle()
-        bundle.putString(FirebaseAnalytics.Param.VALUE, count.toString())
+        bundle.putString(FA.PARAM_VALUE, count.toString())
         trackEvent("satellite_count", bundle)
     }
 
     fun trackSetGuardianGroupStartEvent(screen: Screen) {
         val bundle = Bundle()
-        bundle.putString(FirebaseAnalytics.Param.SOURCE, screen.toString())
+        bundle.putString(FA.PARAM_SOURCE, screen.toString())
         trackEvent("set_guardian_group_start", bundle)
     }
 
     fun trackSeeReportDetailEvent(reportId: String, reportName: String) {
         val bundle = Bundle()
-        bundle.putString(FirebaseAnalytics.Param.ITEM_ID, reportId)
-        bundle.putString(FirebaseAnalytics.Param.ITEM_NAME, reportName)
+        bundle.putString(FA.PARAM_ITEM_ID, reportId)
+        bundle.putString(FA.PARAM_ITEM_NAME, reportName)
         trackEvent("see_report_detail", bundle)
     }
 
     fun trackSeeAlertDetailEvent(eventId: String, eventName: String) {
         val bundle = Bundle()
-        bundle.putString(FirebaseAnalytics.Param.ITEM_ID, eventId)
-        bundle.putString(FirebaseAnalytics.Param.ITEM_NAME, eventName)
+        bundle.putString(FA.PARAM_ITEM_ID, eventId)
+        bundle.putString(FA.PARAM_ITEM_NAME, eventName)
         trackEvent("see_alert_detail", bundle)
     }
 
     fun trackReviewAlertEvent(eventId: String, eventName: String, review: String) {
         val bundle = Bundle()
-        bundle.putString(FirebaseAnalytics.Param.ITEM_ID, eventId)
-        bundle.putString(FirebaseAnalytics.Param.ITEM_NAME, eventName)
-        bundle.putString(FirebaseAnalytics.Param.VALUE, review)
+        bundle.putString(FA.PARAM_ITEM_ID, eventId)
+        bundle.putString(FA.PARAM_ITEM_NAME, eventName)
+        bundle.putString(FA.PARAM_VALUE, review)
         trackEvent("review_alert_detail", bundle)
     }
 
     fun trackFollowAlertEvent(eventId: String, eventName: String) {
         val bundle = Bundle()
-        bundle.putString(FirebaseAnalytics.Param.ITEM_ID, eventId)
-        bundle.putString(FirebaseAnalytics.Param.ITEM_NAME, eventName)
+        bundle.putString(FA.PARAM_ITEM_ID, eventId)
+        bundle.putString(FA.PARAM_ITEM_NAME, eventName)
         trackEvent("follow_alert_detail", bundle)
     }
 


### PR DESCRIPTION
## Replace Firebase Analytics with self-hosted PostHog

Moves product analytics on the RFCx guardian / incidents Android app from Firebase
Analytics to the self-hosted PostHog (`track.rfcx.org`, RFCx project). **Firebase
Crashlytics / Config / Messaging / Firestore / Storage stay** — only
`firebase-analytics` is removed. Mirrors the other rfcx Android cutovers
(companion-android, player-android).

### What
- **build.gradle**: drop `com.google.firebase:firebase-analytics`, add
  `com.posthog:posthog-android:3.+`; add `POSTHOG_API_KEY` (public client token) +
  `POSTHOG_HOST` buildConfigFields on `defaultConfig` (all flavors).
- **Application**: `PostHogAndroid.setup()` with a conservative config
  (`captureScreenViews`/`captureDeepLinks`/`sessionReplay` off; app lifecycle kept).
- **Analytics.kt**: the public API (`trackScreen` + all `trackXEvent` methods) and
  every call site are unchanged; only the two backing methods now send to PostHog
  (`PostHog.screen`/`capture`) via a `Bundle`->`Map` shim. `identify` = the
  signed-in user's email (matches the old `user_email` user-property). Firebase
  reserved event/param names preserved verbatim as local `FA` constants (`login`,
  `item_name`, ...) so the taxonomy is **byte-identical** — only the destination
  changed.

### Note
Native build/verification runs on the Android CI (Gradle + SDK). Public client
token; no secrets.